### PR TITLE
Feature/emptycert

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -29,7 +29,7 @@ type RedisConfig struct {
 
 func NewRedis(config RedisConfig) (Redis, error) {
 	var tlsConfig *tls.Config
-	if config.Address != localAddress || config.CACertFile != "" {
+	if config.Address != localAddress && config.CACertFile != "" {
 		caCert, err := ioutil.ReadFile(config.CACertFile)
 		if err != nil {
 			return Redis{}, err

--- a/redis.go
+++ b/redis.go
@@ -29,7 +29,7 @@ type RedisConfig struct {
 
 func NewRedis(config RedisConfig) (Redis, error) {
 	var tlsConfig *tls.Config
-	if config.Address != localAddress {
+	if config.Address != localAddress || config.CACertFile != "" {
 		caCert, err := ioutil.ReadFile(config.CACertFile)
 		if err != nil {
 			return Redis{}, err


### PR DESCRIPTION
I run redis on my home server now, so i'm no longer configuring `localhost` as my `config.Address`...but i still need to skip the cert

### Why not just change the if statement so it only loads a cert if one is specified?

because most developers have a cert path specified in their local configs to a non existent file path. I don't want to break  their setups